### PR TITLE
Add benchmark bootstrap for shapeless and misc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,28 +1,45 @@
-name := "functadelic"
+import com.typesafe.sbt.SbtScalariform
 
-scalaVersion := "2.11.7"
+lazy val Benchmark = config("bench") extend Test
 
-libraryDependencies ++= Seq(
-  "com.lihaoyi" %% "fastparse" % "0.3.4",
-  "com.storm-enroute" %% "scalameter" % "0.7",
-  "org.scalatest" %% "scalatest" % "3.0.0-M15" % "test"
+/**  This allows running ScalaMeter benchmarks in separate sbt configuration.
+  *  It means, that when you want run your benchmarks you should type 
+  *  `bench:test` in sbt console.
+  */
+lazy val basic = Project(
+  "basic-with-separate-config",
+  file("."),
+  settings = Defaults.coreDefaultSettings ++ 
+    SbtScalariform.scalariformSettings ++ Seq(
+    name := "parsequery",
+    organization := "functadelic",
+    scalaVersion := "2.11.7",
+    scalacOptions ++= Seq(
+      "-Xlint",
+      "-deprecation",
+      "-feature",
+      "-language:higherKinds",
+      "-language:implicitConversions",
+      "-unchecked"
+    ),
+    libraryDependencies ++= Seq(
+      "com.chuusai" %% "shapeless" % "2.2.5",
+      "org.scala-lang" % "scala-compiler" % "2.11.7",
+      "com.storm-enroute" %% "scalameter" % "0.7",
+      "com.lihaoyi" %% "fastparse" % "0.3.4",
+      "org.scalatest" %% "scalatest" % "3.0.0-M15" % "test"
+    ),
+    resolvers ++= Seq(
+      "Sonatype OSS Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots",
+      "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
+    ),
+    testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework"),
+    parallelExecution in Benchmark := false,
+    parallelExecution in Test := false,
+    logBuffered := false
+  )
+) configs(
+  Benchmark
+) settings(
+  inConfig(Benchmark)(Defaults.testSettings): _*
 )
-
-scalacOptions ++= Seq(
-  //"-optimize",
-  "-deprecation",
-  "-feature",
-  "-language:higherKinds",
-  "-language:implicitConversions",
-  "-unchecked"
-)
-
-defaultScalariformSettings
-
-resolvers += "Sonatype OSS Snapshots" at
-  "https://oss.sonatype.org/content/repositories/releases"
-
-testFrameworks += new TestFramework("org.scalameter.ScalaMeterFramework")
-logBuffered := false
-
-parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,3 @@
-import com.typesafe.sbt.SbtScalariform
-
 lazy val Benchmark = config("bench") extend Test
 
 /**  This allows running ScalaMeter benchmarks in separate sbt configuration.
@@ -9,8 +7,7 @@ lazy val Benchmark = config("bench") extend Test
 lazy val basic = Project(
   "basic-with-separate-config",
   file("."),
-  settings = Defaults.coreDefaultSettings ++ 
-    SbtScalariform.scalariformSettings ++ Seq(
+  settings = Defaults.coreDefaultSettings ++ Seq(
     name := "parsequery",
     organization := "functadelic",
     scalaVersion := "2.11.7",

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.3.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,81 @@
+<scalastyle>
+  <name>Scalastyle configuration for Scala.js</name>
+
+  <check level="error" enabled="true" class="org.scalastyle.file.FileTabChecker"/>
+  <check level="error" enabled="true" class="org.scalastyle.file.WhitespaceEndOfLineChecker"/>
+  <check level="error" enabled="true" class="org.scalastyle.file.NewLineAtEofChecker"/>
+
+  <!--Indentation checker, whilst useful gives false positives on the file headers, so disabled for now-->
+  <check level="error" enabled="false" class="org.scalastyle.file.IndentationChecker"/>
+
+  <!--
+  Enforce the hard limit on line length, which is 120 characters.
+  Most of the time the soft limit of 80 characters should be observed, but
+  we can hardly tell an automated style checker about a soft limit.
+  -->
+  <check level="error" enabled="true" class="org.scalastyle.file.FileLineLengthChecker">
+    <parameters>
+      <parameter name="maxLineLength"><![CDATA[120]]></parameter>
+    </parameters>
+  </check>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.RedundantIfChecker"/>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker"/>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.UppercaseLChecker"/>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.ProcedureDeclarationChecker"/>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.ClassNamesChecker">
+    <parameters>
+      <parameter name="regex"><![CDATA[^[A-Z][A-Za-z0-9]*$]]></parameter>
+    </parameters>
+  </check>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.ObjectNamesChecker">
+    <parameters>
+      <parameter name="regex"><![CDATA[^[A-Z][A-Za-z0-9]*$]]></parameter>
+    </parameters>
+  </check>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.PackageObjectNamesChecker">
+    <parameters>
+      <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+    </parameters>
+  </check>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.EqualsHashCodeChecker"/>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.CovariantEqualsChecker"/>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.IllegalImportsChecker">
+    <parameters>
+      <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+    </parameters>
+  </check>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.ReturnChecker"/>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.EmptyClassChecker"/>
+
+  <!-- Currently too strict, see https://github.com/scalastyle/scalastyle/issues/142 -->
+  <check level="error" enabled="false" class="org.scalastyle.scalariform.ForBraceChecker"/>
+
+  <!-- <check level="error" enabled="true" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker"/> -->
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"/>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker"/>
+
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker">
+    <parameters>
+      <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
+    </parameters>
+  </check>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker">
+    <parameters>
+      <parameter name="tokens">LPAREN</parameter>
+    </parameters>
+  </check>
+  <check level="error" enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker">
+    <parameters>
+      <parameter name="tokens">IF, FOR, WHILE, DO, TRY</parameter>
+    </parameters>
+  </check>
+</scalastyle>

--- a/src/main/scala/parsec/CharParsers.scala
+++ b/src/main/scala/parsec/CharParsers.scala
@@ -29,10 +29,9 @@ object HelloCharParsers extends CharParsers {
 
   val (strZ, strCombine) = stringFolder
 
-  val wordDigitLetter: Parser[(String, Char)]
-    = (letters ~ digit).fold(strZ, strCombine) map {
-      case (ls, other) => (ls.toString, other)
-    }
+  val wordDigitLetter: Parser[(String, Char)] = (letters ~ digit).fold(strZ, strCombine) map {
+    case (ls, other) => (ls.toString, other)
+  }
 
   def main(args: Array[String]) {
     val myReader = CharReader("oh3hiagain!".toArray)

--- a/src/main/scala/parsec/CharParsers.scala
+++ b/src/main/scala/parsec/CharParsers.scala
@@ -29,11 +29,12 @@ object HelloCharParsers extends CharParsers {
 
   val (strZ, strCombine) = stringFolder
 
-  val wordDigitLetter: Parser[(String, Char)] = (letters ~ digit).fold(strZ, strCombine) map {
-    case (ls, other) => (ls.toString, other)
-  }
+  val wordDigitLetter: Parser[(String, Char)] = 
+    (letters ~ digit).fold(strZ, strCombine) map {
+      case (ls, other) => (ls.toString, other)
+    }
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val myReader = CharReader("oh3hiagain!".toArray)
     println(wordDigitLetter(myReader))
   }

--- a/src/main/scala/parsec/Parsers.scala
+++ b/src/main/scala/parsec/Parsers.scala
@@ -32,7 +32,6 @@ trait Parsers {
      */
     def ~[U](that: => Parser[U]): Parser[(T, U)] = Seq(this, that)
 
-
     /**
      * get right hand side result
      */
@@ -54,7 +53,7 @@ trait Parsers {
      * alternation, aka the beast
      * Note: actually, it's not much of a beast nomore!
      */
-    def | [U >: T](that: => Parser[U]): Parser[U] = Or(this, that)
+    def |[U >: T](that: => Parser[U]): Parser[U] = Or(this, that)
 
   }
 
@@ -82,7 +81,7 @@ trait Parsers {
    * An ADT for parsers
    */
   case class FlatMapped[T, U](p: Parser[T], f: T => Parser[U]) extends Parser[U] {
-    def apply(in: Input) =  p(in) flatMapWithNext { res => rdr => f(res)(rdr) }
+    def apply(in: Input) = p(in) flatMapWithNext { res => rdr => f(res)(rdr) }
   }
 
   case class Mapped[T, U](p: Parser[T], f: T => U) extends Parser[U] {

--- a/src/main/scala/parsequery/JSONParser.scala
+++ b/src/main/scala/parsequery/JSONParser.scala
@@ -18,7 +18,7 @@ object HelloJSON extends JSONParser {
     val Parsed.Success(resAll, _) = jsonExpr.parse(src)
     val ids2totals: List[(Val, Val)] = (resAll match {
       case x @ Arr(ls) =>
-        for(l <- ls) yield (l("author")("id"), l("total"))
+        for (l <- ls) yield (l("author")("id"), l("total"))
       case _ => sys.error("Something went wrong")
     }).toList
 
@@ -75,77 +75,77 @@ object Js {
  */
 trait JSONParser {
 
-   case class NamedFunction[T, V](f: T => V, name: String) extends (T => V){
-     def apply(t: T) = f(t)
-     override def toString() = name
+  case class NamedFunction[T, V](f: T => V, name: String) extends (T => V) {
+    def apply(t: T) = f(t)
+    override def toString() = name
 
-   }
-   // Here is the parser
-   val Whitespace = NamedFunction(" \r\n".contains(_: Char), "Whitespace")
-   val Digits = NamedFunction('0' to '9' contains (_: Char), "Digits")
-   val StringChars = NamedFunction(!"\"\\".contains(_: Char), "StringChars")
+  }
+  // Here is the parser
+  val Whitespace = NamedFunction(" \r\n".contains(_: Char), "Whitespace")
+  val Digits = NamedFunction('0' to '9' contains (_: Char), "Digits")
+  val StringChars = NamedFunction(!"\"\\".contains(_: Char), "StringChars")
 
-   val space         = P( CharsWhile(Whitespace).? )
-   val digits        = P( CharsWhile(Digits))
-   val exponent      = P( CharIn("eE") ~ CharIn("+-").? ~ digits )
-   val fractional    = P( "." ~ digits )
-   val integral      = P( "0" | CharIn('1' to '9') ~ digits.? )
+  val space = P(CharsWhile(Whitespace).?)
+  val digits = P(CharsWhile(Digits))
+  val exponent = P(CharIn("eE") ~ CharIn("+-").? ~ digits)
+  val fractional = P("." ~ digits)
+  val integral = P("0" | CharIn('1' to '9') ~ digits.?)
 
-   val number = P( CharIn("+-").? ~ integral ~ fractional.? ~ exponent.? ).!.map(
-     x => Js.Num(x.toDouble)
-   )
+  val number = P(CharIn("+-").? ~ integral ~ fractional.? ~ exponent.?).!.map(
+    x => Js.Num(x.toDouble)
+  )
 
-   val `null`        = P( "null" ).map(_ => Js.Null)
-   val `false`       = P( "false" ).map(_ => Js.False)
-   val `true`        = P( "true" ).map(_ => Js.True)
+  val `null` = P("null").map(_ => Js.Null)
+  val `false` = P("false").map(_ => Js.False)
+  val `true` = P("true").map(_ => Js.True)
 
-   val hexDigit      = P( CharIn('0'to'9', 'a'to'f', 'A'to'F') )
-   val unicodeEscape = P( "u" ~ hexDigit ~ hexDigit ~ hexDigit ~ hexDigit )
-   val escape        = P( "\\" ~ (CharIn("\"/\\bfnrt") | unicodeEscape) )
+  val hexDigit = P(CharIn('0' to '9', 'a' to 'f', 'A' to 'F'))
+  val unicodeEscape = P("u" ~ hexDigit ~ hexDigit ~ hexDigit ~ hexDigit)
+  val escape = P("\\" ~ (CharIn("\"/\\bfnrt") | unicodeEscape))
 
-   val strChars = P( CharsWhile(StringChars) )
-   val string =
-     P( space ~ "\"" ~/ (strChars | escape).rep.! ~ "\"").map(Js.Str)
+  val strChars = P(CharsWhile(StringChars))
+  val string =
+    P(space ~ "\"" ~/ (strChars | escape).rep.! ~ "\"").map(Js.Str)
 
-   val array =
-     P( "[" ~/ jsonExpr.rep(sep=",".~/) ~ space ~ "]").map( xs => Js.Arr(xs.toArray))
+  val array =
+    P("[" ~/ jsonExpr.rep(sep = ",".~/) ~ space ~ "]").map(xs => Js.Arr(xs.toArray))
 
-   val pair = P( string.map(_.value) ~/ ":" ~/ jsonExpr )
+  val pair = P(string.map(_.value) ~/ ":" ~/ jsonExpr)
 
-   val obj =
-     P( "{" ~/ pair.rep(sep=",".~/) ~ space ~ "}").map( xs => Js.Obj(xs.toMap) )
+  val obj =
+    P("{" ~/ pair.rep(sep = ",".~/) ~ space ~ "}").map(xs => Js.Obj(xs.toMap))
 
-   val jsonExpr: P[Js.Val] = P(
-     space ~ (obj | array | string | `true` | `false` | `null` | number) ~ space
-   )
+  val jsonExpr: P[Js.Val] = P(
+    space ~ (obj | array | string | `true` | `false` | `null` | number) ~ space
+  )
 
-   /* Define a specialized parser that suits exactly the format of the parsed dataset */
+  /* Define a specialized parser that suits exactly the format of the parsed dataset */
 
-   val total: Parser[Js.Num] = P( "\"total\"" ~ ":" ~ space ~ number ~ space ~ "," ~ space)
+  val total: Parser[Js.Num] = P("\"total\"" ~ ":" ~ space ~ number ~ space ~ "," ~ space)
 
-   val notRightBracket = NamedFunction(!"]".contains(_: Char), "NotRightBracket")
-   val anyCharNotRightBracket = P( CharsWhile(notRightBracket) )
-   val notRightCurlyBracket = NamedFunction(!"}".contains(_: Char), "NotRightCurlyBracket")
-   val untilRightCurlyBracket = P( CharsWhile(notRightCurlyBracket) )
-   val untilCommaFunction = NamedFunction(!",".contains(_: Char), "UntilComma")
-   val untilComma = P( CharsWhile(untilCommaFunction) )
+  val notRightBracket = NamedFunction(!"]".contains(_: Char), "NotRightBracket")
+  val anyCharNotRightBracket = P(CharsWhile(notRightBracket))
+  val notRightCurlyBracket = NamedFunction(!"}".contains(_: Char), "NotRightCurlyBracket")
+  val untilRightCurlyBracket = P(CharsWhile(notRightCurlyBracket))
+  val untilCommaFunction = NamedFunction(!",".contains(_: Char), "UntilComma")
+  val untilComma = P(CharsWhile(untilCommaFunction))
 
-   val logged = scala.collection.mutable.Buffer.empty[String]
-   implicit val logger = fastparse.Logger(logged.append(_))
-   val stringPair = P( string ~ ":" ~ space ~ string ~ space ~ "," )
+  val logged = scala.collection.mutable.Buffer.empty[String]
+  implicit val logger = fastparse.Logger(logged.append(_))
+  val stringPair = P(string ~ ":" ~ space ~ string ~ space ~ ",")
 
-   val unitToken = Js.Unitt('a')
-   val weeks: Parser[Js.Unitt] = P( "\"weeks\"" ~ space ~ ":" ~ space ~
-     "[" ~ space ~ anyCharNotRightBracket ~ space ~ "]," ~ space).map(_ => unitToken)
-   val author: Parser[Js.Str] = P("\"author\"" ~ space ~ ":" ~ space ~
-     "{" ~ space ~ "\"login\"" ~ space ~ ":" ~ space ~ string ~ "," ~
-     untilComma.rep(sep=",",max=15) ~ space ~ untilRightCurlyBracket ~ space ~  "}" ~ space)
+  val unitToken = Js.Unitt('a')
+  val weeks: Parser[Js.Unitt] = P("\"weeks\"" ~ space ~ ":" ~ space ~
+    "[" ~ space ~ anyCharNotRightBracket ~ space ~ "]," ~ space).map(_ => unitToken)
+  val author: Parser[Js.Str] = P("\"author\"" ~ space ~ ":" ~ space ~
+    "{" ~ space ~ "\"login\"" ~ space ~ ":" ~ space ~ string ~ "," ~
+    untilComma.rep(sep = ",", max = 15) ~ space ~ untilRightCurlyBracket ~ space ~ "}" ~ space)
 
-   val projection: P[Js.Arr] =
-     P( space ~ "{" ~ space ~ total ~ weeks ~ author ~ space ~ "}" ~ space).map {
-       case (t,w,a) => Js.Arr(Array(t, a))
-     }
+  val projection: P[Js.Arr] =
+    P(space ~ "{" ~ space ~ total ~ weeks ~ author ~ space ~ "}" ~ space).map {
+      case (t, w, a) => Js.Arr(Array(t, a))
+    }
 
-   val projections: P[Js.Arr] =
-     P( "[" ~/ projection.rep(sep=",".~/) ~ "]").map(xs => Js.Arr(xs.toArray))
+  val projections: P[Js.Arr] =
+    P("[" ~/ projection.rep(sep = ",".~/) ~ "]").map(xs => Js.Arr(xs.toArray))
 }

--- a/src/main/scala/parsequery/JSONParser.scala
+++ b/src/main/scala/parsequery/JSONParser.scala
@@ -52,7 +52,6 @@ object Js {
       this.asInstanceOf[Obj].value.find(_._1 == s).get._2
   }
 
-  case class Unitt(value: Char) extends AnyVal with Val
   case class Str(value: java.lang.String) extends AnyVal with Val
   case class Obj(value: Map[java.lang.String, Val]) extends AnyVal with Val
   case class Arr(value: Array[Val]) extends AnyVal with Val
@@ -132,18 +131,21 @@ trait JSONParser {
 
   val logged = scala.collection.mutable.Buffer.empty[String]
   implicit val logger = fastparse.Logger(logged.append(_))
+
   val stringPair = P(string ~ ":" ~ space ~ string ~ space ~ ",")
 
-  val unitToken = Js.Unitt('a')
-  val weeks: Parser[Js.Unitt] = P("\"weeks\"" ~ space ~ ":" ~ space ~
-    "[" ~ space ~ anyCharNotRightBracket ~ space ~ "]," ~ space).map(_ => unitToken)
-  val author: Parser[Js.Str] = P("\"author\"" ~ space ~ ":" ~ space ~
-    "{" ~ space ~ "\"login\"" ~ space ~ ":" ~ space ~ string ~ "," ~
-    untilComma.rep(sep = ",", max = 15) ~ space ~ untilRightCurlyBracket ~ space ~ "}" ~ space)
+  val weeks: Parser[Unit] = P("\"weeks\"" ~ space ~ ":" ~ space ~
+    "[" ~ space ~ anyCharNotRightBracket ~ space ~ "]," ~ space).map(_ => ())
+
+  val author: Parser[Js.Str] = P {
+    "\"author\"" ~ space ~ ":" ~ space ~ "{" ~ space ~ "\"login\"" ~ 
+    space ~ ":" ~ space ~ string ~ "," ~ untilComma.rep(sep = ",", max = 15) ~ 
+    space ~ untilRightCurlyBracket ~ space ~ "}" ~ space
+  }
 
   val projection: P[Js.Arr] =
     P(space ~ "{" ~ space ~ total ~ weeks ~ author ~ space ~ "}" ~ space).map {
-      case (t, w, a) => Js.Arr(Array(t, a))
+      case (t, a) => Js.Arr(Array(t, a))
     }
 
   val projections: P[Js.Arr] =

--- a/src/main/scala/parsequery/JSONParser.scala
+++ b/src/main/scala/parsequery/JSONParser.scala
@@ -6,7 +6,7 @@ object HelloJSON extends JSONParser {
 
   import Js._
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
 
     val src: String = io.Source.fromFile("data/scala-lang-contributions.json").mkString
 
@@ -59,13 +59,13 @@ object Js {
   case class Num(value: Double) extends AnyVal with Val
 
   case object False extends Val {
-    def value = false
+    def value: Boolean = false
   }
   case object True extends Val {
-    def value = true
+    def value: Boolean = true
   }
   case object Null extends Val {
-    def value = null
+    def value: Val = null
   }
 }
 
@@ -76,10 +76,10 @@ object Js {
 trait JSONParser {
 
   case class NamedFunction[T, V](f: T => V, name: String) extends (T => V) {
-    def apply(t: T) = f(t)
-    override def toString() = name
-
+    def apply(t: T): V = f(t)
+    override def toString(): String = name
   }
+
   // Here is the parser
   val Whitespace = NamedFunction(" \r\n".contains(_: Char), "Whitespace")
   val Digits = NamedFunction('0' to '9' contains (_: Char), "Digits")

--- a/src/test/scala/parsec/TestCharParsers.scala
+++ b/src/test/scala/parsec/TestCharParsers.scala
@@ -39,10 +39,9 @@ class CharParsersSuite
   test("can parse a word, a digit, and another letter") {
     val (strZ, strCombine) = stringFolder
 
-    val wordDigitLetter: Parser[(String, (Char, Char))]
-      = (letters ~ digit ~ letter).fold(strZ, strCombine) map {
-          case (ls, other) => (ls.toString, other)
-        }
+    val wordDigitLetter: Parser[(String, (Char, Char))] = (letters ~ digit ~ letter).fold(strZ, strCombine) map {
+      case (ls, other) => (ls.toString, other)
+    }
 
     wordDigitLetter(myReader) match {
       case Success(res, rest) => rest match {

--- a/src/test/scala/parsec/TestCharParsers.scala
+++ b/src/test/scala/parsec/TestCharParsers.scala
@@ -25,7 +25,8 @@ class CharParsersSuite
 
   test("can parse a word") {
     val (strZ, strCombine) = stringFolder
-    val wordParser: Parser[String] = letters.fold(strZ, strCombine).map(_.toString)
+    val wordParser: Parser[String] = 
+      letters.fold(strZ, strCombine).map(_.toString)
 
     wordParser(myReader) match {
       case Success(res, rest) => rest match {
@@ -39,9 +40,10 @@ class CharParsersSuite
   test("can parse a word, a digit, and another letter") {
     val (strZ, strCombine) = stringFolder
 
-    val wordDigitLetter: Parser[(String, (Char, Char))] = (letters ~ digit ~ letter).fold(strZ, strCombine) map {
-      case (ls, other) => (ls.toString, other)
-    }
+    val wordDigitLetter: Parser[(String, (Char, Char))] = 
+      (letters ~ digit ~ letter).fold(strZ, strCombine) map {
+        case (ls, other) => (ls.toString, other)
+      }
 
     wordDigitLetter(myReader) match {
       case Success(res, rest) => rest match {

--- a/src/test/scala/parsequery/ParsequeryBenchmark.scala
+++ b/src/test/scala/parsequery/ParsequeryBenchmark.scala
@@ -26,21 +26,21 @@ object ParsequeryBenchmark
 
     val range = Gen.enumeration("size")(10)
     performance of fname in {
-      measure method "parser" config(
+      measure method "parser" config (
         exec.minWarmupRuns -> 5,
         exec.maxWarmupRuns -> 10,
         exec.benchRuns -> 25,
         exec.independentSamples -> 4
       ) in {
-        using(range) in { n =>
-          // we use while to remove overhead of for ... yield
-          var i=0
-          while (i < n) {
-            f(fileContent)
-            i+=1
+          using(range) in { n =>
+            // we use while to remove overhead of for ... yield
+            var i = 0
+            while (i < n) {
+              f(fileContent)
+              i += 1
+            }
           }
         }
-      }
     }
   }
 
@@ -48,7 +48,7 @@ object ParsequeryBenchmark
     val Parsed.Success(resAll, _) = jsonExpr.parse(src)
     val ids2totals: List[(Val, Val)] = (resAll match {
       case x @ Arr(ls) =>
-        for(l <- ls) yield (l("author")("id"), l("total"))
+        for (l <- ls) yield (l("author")("id"), l("total"))
       case _ => sys.error("Something went wrong")
     }).toList
   }

--- a/src/test/scala/shapeless/Benchmark.scala
+++ b/src/test/scala/shapeless/Benchmark.scala
@@ -1,0 +1,34 @@
+import scala.tools.nsc._
+
+import org.scalameter.api._
+import org.scalameter.picklers.Implicits._
+
+object Benchmark extends Bench.ForkedTime {
+
+  override def persistor = Persistor.None
+  override def reporter = new LoggingReporter
+
+  val range = Gen.enumeration("size")(10)
+
+  performance of "Compilation of shapeless" in {
+    measure method "scala-compiler" config (
+      exec.minWarmupRuns -> 5,
+      exec.maxWarmupRuns -> 10,
+      exec.benchRuns -> 15,
+      exec.independentSamples -> 4
+    ) in {
+        using(range) in { n =>
+
+          /* Let's create a new scala compiler! */
+          val s = new Settings
+          s.usejavacp.value = true
+          val compiler = new Global(s)
+          val run = new compiler.Run()
+
+          run.compile(List("src/test/scala/shapeless/Shapeless.scala"))
+
+        }
+      }
+  }
+
+}

--- a/src/test/scala/shapeless/Shapeless.scala
+++ b/src/test/scala/shapeless/Shapeless.scala
@@ -1,0 +1,25 @@
+import shapeless._
+import poly._
+
+/**
+ * This source code is compiled by an embedded to check
+ * the compilation time of HList for extreme cases.
+ *
+ * Currently, there is only a dummy test that should be
+ * replaced for more concrete and extensive examples of
+ * use of parsequery.
+ */
+object Shapeless {
+  def test(a: String, b: Int, c: Double, d: Char) =
+    a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d ::
+      a :: b :: c :: d :: HNil
+
+  (0 to 100).map(_ => test("foo.bar.baz", 123123, 431.4, 'a'))
+}


### PR DESCRIPTION
- Add a bootstrap file to write the parsequery benchmarks on shapeless
- Use Scala compiler API to compile on the fly
- Rewrite `build.sbt` to better Scalameter configuration
- Add Scalariform settings and run formatter
