### PR TITLE
Cps reader

### DIFF
--- a/core/src/main/scala/parsec/Test.scala
+++ b/core/src/main/scala/parsec/Test.scala
@@ -40,9 +40,9 @@ object Test extends OptimisedParsers {
     val fileName = "data/booleans-6600.json"
     val fileContent = Source.fromFile(fileName).mkString
     //val myReader = CharReader(fileContent.toArray)
-    val myReader = CharReader("\"hello people\"".toArray)
+    val myReader = CharReader("hello people".toArray)
 
-    val stringLitParser = optimise(stringLiteral)
+    val stringLitParser = optimise(rep(letter))
 
     val Success(res, rest) = stringLitParser(myReader)
     println(res)

--- a/core/src/main/scala/parsec/examples/JSONParser.scala
+++ b/core/src/main/scala/parsec/examples/JSONParser.scala
@@ -1,6 +1,7 @@
 package parsec.examples
 
 import parsec.optimised.OptimisedParsers
+import parsec._
 
 object JSONParser extends OptimisedParsers {
 
@@ -24,17 +25,32 @@ object JSONParser extends OptimisedParsers {
       accept("false").map(_ => JSBool(false))
     )
 
-    def obj: Parser[JSValue] = (
-      skipWs(accept('{')) ~> repsep(member, skipWs(accept(','))) <~ skipWs(accept('}'))
-    ) map { x => JSObject(x) }
+    def obj: Parser[JSValue] = (skipWs(accept('{')) ~>
+      repsep(member, skipWs(accept(',')))
+    <~ skipWs(accept('}'))) map { x => JSObject(x) }
 
-    def arr: Parser[JSValue] = (
-      skipWs(accept('[')) ~> repsep(main, skipWs(accept(','))) <~ skipWs(accept(']'))
-    ) map { x => JSArray(x) }
+    def arr: Parser[JSValue] = (skipWs(accept('[')) ~>
+      repsep(main, skipWs(accept(',')))
+    <~ skipWs(accept(']'))) map { x => JSArray(x) }
 
     def member: Parser[(String, JSValue)] =
       stringLiteral ~ (skipWs(accept(':')) ~> main)
 
     main
+  }
+
+  def main(args: Array[String]): Unit = {
+    println("greetings lion")
+
+    import scala.io.Source
+    val fileName = "data/booleans-6600.json"
+    val fileContent = Source.fromFile(fileName).mkString
+    val myReader = CharReader(fileContent.toArray)
+
+    val Success(res, rest) = jsonParser(myReader)
+    res match {
+      case JSArray(ls) => println(ls.length)
+      case _ => println("something else")
+    }
   }
 }

--- a/macros/src/bench/scala/util/BenchmarkHelper.scala
+++ b/macros/src/bench/scala/util/BenchmarkHelper.scala
@@ -20,7 +20,7 @@ trait BenchmarkHelper extends Bench.ForkedTime with java.io.Serializable {
 
   override def executor = SeparateJvmsExecutor(
     new Executor.Warmer.Default,
-    Aggregator.min[Double],
+    Aggregator.average,
     new Measurer.Default
   )
 

--- a/macros/src/main/scala/parsec/Reader.scala
+++ b/macros/src/main/scala/parsec/Reader.scala
@@ -6,6 +6,12 @@ trait Reader[+T] {
   def rest: Reader[T]
   def atEnd: Boolean
 
+  /**
+   * TODO: should every reader have a source?
+   * and a pos?
+   */
+  def source: Array[Char]
+  def pos: Int
 }
 
 trait StringReader[+T] extends Reader[T] {

--- a/macros/src/main/scala/parsec/optimised/CharReaderOps.scala
+++ b/macros/src/main/scala/parsec/optimised/CharReaderOps.scala
@@ -1,0 +1,57 @@
+package parsec.optimised
+
+import scala.reflect.macros.blackbox.Context
+import util.Zeroval
+
+trait ReaderOps {
+
+  val c: Context
+  import c.universe._
+
+  abstract class Reader(elemType: Type) {
+    def first: Tree
+    def atEnd: Tree
+    def rest: Reader
+  }
+
+  /**
+   * a CPS-encoded implementation of the CharReader datatype
+   *
+   * for reminder sake:
+   *   CharReader =
+   *     forall X. ((source: Array[Char], pos: Int) => X) => X
+   */
+  abstract class CharReader extends Reader(typeOf[Char]) { self =>
+    def apply(cont: (Tree, Tree) => Tree): Tree
+
+    def first = self.apply((source, pos) => q"$source($pos)")
+    def atEnd = self.apply((source, pos) => q"$pos >= $source.length")
+    def rest = new CharReader {
+      def apply(cont: (Tree, Tree) => Tree) =
+        self.apply((source, pos) => cont(source, q"$pos + 1"))
+    }
+
+    def getSource = self.apply((src, _) => src)
+    def getPos = self.apply((_, p) => p)
+
+    def toCharReader: Tree = self.apply {
+      (source, pos) => q"CharReader($source, $pos)"
+    }
+  }
+
+  def mkCharReader(source: Tree, pos: Tree) = new CharReader {
+    def apply(cont: (Tree, Tree) => Tree) = cont(source, pos)
+  }
+
+  def cond(test: Tree, thenp: CharReader, elsep: CharReader) = {
+    new CharReader {
+      def apply(cont: (Tree, Tree) => Tree) = {
+        q"""
+          if ($test) ${thenp(cont)}
+          else       ${elsep(cont)}
+        """
+      }
+    }
+  }
+
+}

--- a/macros/src/main/scala/parsec/optimised/OptimisedParsers.scala
+++ b/macros/src/main/scala/parsec/optimised/OptimisedParsers.scala
@@ -131,7 +131,20 @@ class OptimisedParsersImpl(val c: Context) extends StagedGrammars {
         val mapped = optionP map { parser =>
           val inputTerm = TermName(c.freshName("input"))
           val in = q"$inputTerm"
-          q"Parser { ($in: Input) => ${parser(in).toParseResult} }"
+
+          val sourceTerm = TermName(c.freshName("source"))
+          val source = q"$sourceTerm"
+
+          val tmpPosTerm = TermName(c.freshName("tmpPos"))
+          val tmpPos = q"$tmpPosTerm"
+
+          q"""Parser { ($in: Input) =>
+            var $sourceTerm: Array[Char] = $in.source
+            var $tmpPosTerm: Int = $in.pos
+
+            ${parser(mkCharReader(source, tmpPos)).toParseResult}
+          }
+          """
         }
         (name -> mapped)
       }

--- a/macros/src/main/scala/parsec/optimised/ParseResultOps.scala
+++ b/macros/src/main/scala/parsec/optimised/ParseResultOps.scala
@@ -30,100 +30,46 @@ trait ParseResultOps { self: ReaderOps with Zeroval =>
        * later
        */
       def apply(success: (Tree, CharReader) => Tree, failure: CharReader => Tree): Tree = {
-        val isSuccessTerm = TermName(c.freshName("success"))
-        val isSuccess = q"$isSuccessTerm"
-
-        val sourceTerm = TermName(c.freshName("source"))
-        val source = q"$sourceTerm"
-
-        val tmpPosTerm = TermName(c.freshName("tmpPos"))
-        val tmpPos = q"$tmpPosTerm"
-
-        val tmpResTerm = TermName(c.freshName("tmpRes"))
-        val tmpRes = q"$tmpResTerm"
-
-        val applied = self.apply(
-          (res, rest) => {
-
-            val readerApplied = rest.apply {
-              (src, pos) => q"$source = $src; $tmpPos = $pos"
-            }
-
-            q"""
-              $tmpRes = $res
-              $readerApplied
-              $isSuccess = true
-            """
-          },
-
-          rest => rest.apply {
-            (src, pos) => q"$source = $src; $tmpPos = $pos"
-          }
+        self.apply(
+          (res, rest) => success(f(res), rest),
+          failure
         )
-
-        q"""
-          var $isSuccessTerm: Boolean = false
-          var $tmpResTerm: ${self.elemType} = ${zeroValue(self.elemType)}
-          var $sourceTerm: Array[Char] = null
-          var $tmpPosTerm: Int = 0
-
-          $applied
-
-          if ($isSuccess) ${success(f(tmpRes), mkCharReader(source, tmpPos)) }
-          else ${failure(mkCharReader(source, tmpPos))}
-        """
       }
     }
 
-    def flatMapWithNext(t: Type, f: Tree => CharReader => ParseResult) =  {
+    def flatMapWithNext(t: Type, f: Tree => CharReader => ParseResult) = {
       new ParseResult(t) {
         def apply(success: (Tree, CharReader) => Tree, failure: CharReader => Tree) = {
-          val isSuccessTerm = TermName(c.freshName("success"))
-          val isSuccess = q"$isSuccessTerm"
-
-          val sourceTerm = TermName(c.freshName("source"))
-          val source = q"$sourceTerm"
-
-          val tmpPosTerm = TermName(c.freshName("tmpPos"))
-          val tmpPos = q"$tmpPosTerm"
-
-          val tmpResTerm = TermName(c.freshName("tmpRes"))
-          val tmpRes = q"$tmpResTerm"
-
-          val applied = self.apply(
-            (res, rest) => {
-
-              val readerApplied = rest.apply {
-                (src, pos) => q"$source = $src; $tmpPos = $pos"
-              }
-
-              q"""
-                $tmpRes = $res
-                $readerApplied
-                $isSuccess = true
-              """
-            },
-            rest => rest.apply {
-              (src, pos) => q"$source = $src; $tmpPos = $pos"
-            }
+          self.apply(
+            (res, rest) => f(res)(rest).apply(success, failure),
+            failure
           )
-
-          q"""
-            var $isSuccessTerm: Boolean = false
-            var $tmpResTerm: ${self.elemType} = ${zeroValue(self.elemType)}
-            var $sourceTerm: Array[Char] = null
-            var $tmpPosTerm: Int = 0
-
-            $applied
-
-            if ($isSuccess) ${f(tmpRes)(mkCharReader(source, tmpPos)).apply(success, failure)}
-            else ${failure(mkCharReader(source, tmpPos))}
-          """
         }
       }
     }
 
     def orElse(t: Type, that: ParseResult) = new ParseResult(t) {
+
+//      def apply[X: Typ](
+//        success: (Rep[T], Rep[Input]) => Rep[X],
+//        failure: Rep[Input] => Rep[X]): Rep[X] =  {
+//
+//        var isSuccess = unit(false)
+//        var value = zeroVal[T]
+//        var rdr = zeroVal[Input]
+//
+//        val successK = (t: Rep[T], rest: Rep[Input]) => {
+//          isSuccess = unit(true)
+//          value = t
+//          rdr = rest
+//        }
+//        val failK = (rest: Rep[Input]) => { rdr = rest }
+//        self.apply(successK, failK)
+//
+//        if (isSuccess) mkSuccess(value, rdr)
+//        else           that
+//      }
+
       val isSuccessTerm = TermName(c.freshName("success"))
       val isSuccess = q"$isSuccessTerm"
 
@@ -136,20 +82,27 @@ trait ParseResultOps { self: ReaderOps with Zeroval =>
       val tmpResTerm = TermName(c.freshName("tmpRes"))
       val tmpRes = q"$tmpResTerm"
 
-      val applied = self.apply(
-        (res, rest) => {
+      val successK = (res: Tree, rest: CharReader) => {
+        val readerApplied = rest.apply {
+          (src, pos) => q"$source = $src; $tmpPos = $pos"
+        }
 
-          val readerApplied = rest.apply {
-            (src, pos) => q"$source = $src; $tmpPos = $pos"
-          }
+        q"""
+        $isSuccess = true
+        $tmpRes = $res
+        $readerApplied
+        """
+      }
 
-          q"""
-            $isSuccess = true
-            $tmpRes = $res
-            $readerApplied
-          """
-        },
-        rest => q"()" // we don't need to do anything in this case
+      val failureK = (rest: CharReader) => rest.apply { (src, pos) =>
+        q"""$source = $src; $tmpPos = $pos"""
+      }
+
+      val applied = self.apply(successK, failureK)
+      val conditioned = cond(t)(
+        q"$isSuccess",
+        mkSuccess(this.elemType, tmpRes, mkCharReader(source, tmpPos)),
+        that
       )
 
       def apply(success: (Tree, CharReader) => Tree, failure: CharReader => Tree) = {
@@ -160,52 +113,15 @@ trait ParseResultOps { self: ReaderOps with Zeroval =>
         var $tmpResTerm: ${this.elemType} = ${zeroValue(this.elemType)}
 
         $applied
-
-        if ($isSuccess) ${success(tmpRes, mkCharReader(source, tmpPos))}
-        else ${that.apply(success, failure)}
+        ${conditioned.apply(success, failure)}
         """
       }
     }
 
-    def toParseResult: Tree = {
-      /**
-       * A parser returns a CPS-encoded ParseResult,
-       * we have to inline it here.
-       */
-      val isSuccessTerm = TermName(c.freshName("success"))
-      val success = q"$isSuccessTerm"
-
-      val resTerm = TermName(c.freshName("res"))
-      val res = q"$resTerm"
-
-      /**
-       * This is the only place where we will create an input
-       * Otherwise we stay in the CPS encoding
-       */
-      val inputTerm = TermName(c.freshName("input"))
-      val input = q"$inputTerm"
-
-      val applied = this.apply(
-        (result, rest) => q"""
-          $success = true
-          $res = $result
-          $input = ${rest.toCharReader}
-        """,
-
-        (rest) => q"""
-          $success = false
-          $input = ${rest.toCharReader}
-        """
-      )
-
-      q"""
-        var $isSuccessTerm: Boolean = false
-        var $resTerm: $elemType = ${zeroValue(elemType)}
-        var $inputTerm: Input = null
-        $applied
-        if ($success) Success($res, $input) else Failure("oh noes!", $input)
-      """
-    }
+    def toParseResult: Tree = this.apply(
+      (result, rest) => q"""Success($result, ${rest.toCharReader})""",
+      rest => q"""Failure("oh noes!", ${rest.toCharReader})"""
+    )
   }
 
   def mkSuccess(elemType: Type, elem: Tree, rest: CharReader) = new ParseResult(elemType) {
@@ -221,9 +137,51 @@ trait ParseResultOps { self: ReaderOps with Zeroval =>
   def cond(elemType: Type)(test: Tree, thenp: ParseResult, elsep: ParseResult) = {
     new ParseResult(elemType) {
       def apply(success: (Tree, CharReader) => Tree, failure: CharReader => Tree) = {
+
+        val isSuccessTerm = TermName(c.freshName("success"))
+        val isSuccess = q"$isSuccessTerm"
+
+        val resTerm = TermName(c.freshName("res"))
+        val res = q"$resTerm"
+
+        val sourceTerm = TermName(c.freshName("source"))
+        val source = q"$sourceTerm"
+
+        val tmpPosTerm = TermName(c.freshName("tmpPos"))
+        val tmpPos = q"$tmpPosTerm"
+
+        val successK = (result: Tree, rest: CharReader) => {
+
+          val readerApplied = rest.apply {
+            (src, pos) => q"$source = $src; $tmpPos = $pos"
+          }
+
+          q"""
+            $isSuccess = true
+            $res = $result
+            $readerApplied
+          """
+        }
+
+        val failureK = (rest: CharReader) => rest.apply {
+          (src, pos) => q"$source = $src; $tmpPos = $pos"
+        }
+
+        val applied = q"""
+          if ($test) ${ thenp.apply(successK, failureK) }
+          else       ${ elsep.apply(successK, failureK) }
+        """
+
         q"""
-          if ($test) ${thenp(success, failure)}
-          else       ${elsep(success, failure)}
+          var $isSuccessTerm: Boolean = false
+          var $resTerm: ${this.elemType} = ${zeroValue(this.elemType)}
+          var $sourceTerm: Array[Char] = null
+          var $tmpPosTerm: Int = 0
+
+          $applied
+
+          if ($isSuccess) ${success(res, mkCharReader(source, tmpPos))}
+          else            ${failure(mkCharReader(source, tmpPos))}
         """
       }
     }

--- a/macros/src/test/scala/parsec/optimised/TestOptimisedParsers.scala
+++ b/macros/src/test/scala/parsec/optimised/TestOptimisedParsers.scala
@@ -187,7 +187,6 @@ class OptimisedParserSuite
 
   }
 
-
   test("basic recursion works") {
 
     val listOfAsParser = optimise {


### PR DESCRIPTION
Now we CPS-encode the Reader as well. As a result, a `CharReader` is only created at function borders. This considerable improves the performance of the `OptimisedJSON` benchmark (see diff). For comparison, here is a table of before/after:

```
            FastParse    FastParseJSON    _Optimised_    _OptimisedJSON_    HandWritten    fold2ArrayBuffer

Before      195             543               129               465                110            456
After       180             541                78               342                101            416

```

Note that only the benchmarks in bold have this optimisation applied. The others stay more or less the same.
